### PR TITLE
fix: contact actions should preserve pathname

### DIFF
--- a/src/routes/Contact/List.tsx
+++ b/src/routes/Contact/List.tsx
@@ -79,7 +79,12 @@ const ContactList = forwardRef<HTMLDivElement, HTMLProps<HTMLDivElement>>(
       >
         <H2 className="mx-6 mb-3">Contact</H2>
 
-        <Form id="search-contact" role="search" className="mx-6 mb-3">
+        <Form
+          id="search-contact"
+          role="search"
+          className="mx-6 mb-3"
+          action={location.pathname}
+        >
           <Input
             name="name"
             ref={nameRef}

--- a/src/routes/Contact/useSearchContactForm.ts
+++ b/src/routes/Contact/useSearchContactForm.ts
@@ -5,7 +5,7 @@ import {
   type ChangeEventHandler,
   type RefObject,
 } from 'react';
-import { useSubmit } from 'react-router-dom';
+import { useNavigate, useSubmit } from 'react-router-dom';
 import type { CharacterFilter } from 'rickmortyapi';
 import { useDebounce, useKey } from 'rooks';
 
@@ -50,6 +50,7 @@ const useSearchContactForm = (filters: CharacterFilter) => {
   );
 
   const submit = useSubmit();
+  const navigate = useNavigate();
   const debouncedSubmit: typeof submit = useDebounce(submit, 500);
 
   const onFormChange: ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -58,11 +59,8 @@ const useSearchContactForm = (filters: CharacterFilter) => {
   );
 
   const resetFilters = useCallback(() => {
-    [nameRef, statusRef, genderRef].forEach(inputRef =>
-      setRefValue(inputRef, '')
-    );
-    submit(new FormData());
-  }, [submit]);
+    navigate(`?name=${nameRef.current?.value}`);
+  }, [navigate]);
 
   const hasActiveFilter = !!(filters.status || filters.gender || filters.name);
 

--- a/src/utils/test.tsx
+++ b/src/utils/test.tsx
@@ -31,14 +31,6 @@ const createQueryClient = () =>
         cacheTime: Infinity,
       },
     },
-    logger: {
-      /* eslint-disable no-console */
-      log: console.log,
-      warn: console.warn,
-      // ✅ no more errors on the console for tests
-      error: process.env.NODE_ENV === 'test' ? () => {} : console.error,
-      /* eslint-enable no-console */
-    },
     queryCache: new QueryCache({
       onError: generalErrorToast,
     }),


### PR DESCRIPTION
- when applying search, filters, should keep :id in the pathname to prevent the current details page being reset
- mute logger deprecated error in tests